### PR TITLE
Corrected formatting of logger with provider error

### DIFF
--- a/ytmdl/metadata.py
+++ b/ytmdl/metadata.py
@@ -21,7 +21,7 @@ def _logger_provider_error(exception, name):
     """Show error if providers throw an error"""
     logger.debug('{}'.format(exception))
     logger.error(
-        "Something went wrong with {}. The program will continue with"
+        "Something went wrong with {}. The program will continue with "
         "the other providers. Please check '{}' for more details.\
             ".format(name, logger.get_log_file()))
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/deepjyoti30/ytmdl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [ytmdl coding conventions](https://github.com/deepjyoti30/ytmdl/blob/master/.github/CONTRIBUTING.md) and adjusted the code to meet them
- [x] Checked the code with [pylama](https://github.com/klen/pylama)
- [ ] Made the pull request to the **unstable** branch - seems to be outdated

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

The words "with" and "the" in the logger for errors with the providers were formatted without whitespace between them before. By adding a space between them, the words will be properly seperated in the logger.
